### PR TITLE
catch errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ VizioSoundbar.prototype.getPowerState = function(callback) {
 
 		callback(null, isPowerOn);
 
-	});
+	}).catch(callback);
 
 }
 
@@ -88,9 +88,9 @@ VizioSoundbar.prototype.setPowerState = function(state, callback) {
                 var status = result.STATUS.RESULT;
                 var success = status == "SUCCESS" ? 1 : 0;
                 callback(null, success);
-            });
+            }).catch(callback);
         }
-	});
+	}).catch(callback);
 
 
 


### PR DESCRIPTION
Catching the errors keeps homebridge from flooding the logs with broken promise errors. Catching these errors keeps the Home app on my devices running quickly. Without these failing requests would slow down the UI and make things awkward.